### PR TITLE
 Add binary dataset generators and BinaryApriori miner; fix parsing & state bugs

### DIFF
--- a/PAMI/extras/generateDatabase/generateBinaryDatabase.py
+++ b/PAMI/extras/generateDatabase/generateBinaryDatabase.py
@@ -1,0 +1,129 @@
+# generateBinaryDatabase generates a synthetic binary (0/1) transactional database.
+#
+#  **Importing this algorithm into a python program**
+#  --------------------------------------------------------
+#     from PAMI.extras.generateDatabase import generateBinaryDatabase as db
+#     obj = db.generateBinaryDatabase(10, 5, 10)
+#     obj.create()
+#     obj.save('\t', 'binaryDB.txt')
+#     print(obj.getTransactions()) to get the binary database as a pandas dataframe
+
+# **Running the code from the command line**
+# --------------------------------------------------------
+#     python generateBinaryDatabase.py 10 5 10 binaryDB.txt
+#     cat binaryDB.txt
+#
+
+
+__copyright__ = """
+Copyright (C)  2026 Rage Uday Kiran
+
+     This program is free software: you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+     the Free Software Foundation, either version 3 of the License, or
+     (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License
+     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+
+import numpy as np
+import pandas as pd
+import sys
+
+
+class generateBinaryDatabase:
+    """
+    :Description: Generate a synthetic binary (0/1) transactional database with the given number of lines
+                  (transactions), average number of present items per line, and total number of items. Rows are
+                  transactions and columns are items; a 1 means the item is present in that transaction.
+
+    :Attributes:
+    numLines: int
+        - number of lines (transactions)
+    avgItemsPerLine: int
+        - average number of present items (1s) per line
+    numItems: int
+        - total number of items (columns)
+
+    :Methods:
+        create:
+            Generate the binary database
+        save:
+            Save the binary database to a file
+        getTransactions:
+            Get the binary database as a pandas DataFrame
+    """
+
+    def __init__(self, numLines, avgItemsPerLine, numItems) -> None:
+        """
+        Initialize the binary database with the given parameters
+
+        :param numLines: number of lines (transactions)
+        :param avgItemsPerLine: average number of present items per line
+        :param numItems: total number of items
+        """
+
+        self.numLines = numLines
+        self.avgItemsPerLine = avgItemsPerLine
+        self.numItems = numItems
+        self.db = None
+
+    def create(self) -> None:
+        """
+        Generate the binary database as a (numLines x numItems) 0/1 matrix.
+
+        :return: None
+        """
+        # Per-line 1-counts averaging avgItemsPerLine, bounded by [1, numItems].
+        counts = np.random.poisson(self.avgItemsPerLine, self.numLines)
+        counts = np.clip(counts, 1, self.numItems)
+
+        matrix = np.zeros((self.numLines, self.numItems), dtype=np.uint8)
+        for i in range(self.numLines):
+            chosen = np.random.choice(self.numItems, counts[i], replace=False)
+            matrix[i, chosen] = 1
+        self.db = matrix
+
+    def save(self, sep, filename) -> None:
+        """
+        Save the binary database to a file, one transaction per line as sep-separated 0/1 values.
+
+        :param sep: separator
+        :type sep: str
+        :param filename: name of the file
+        :type filename: str
+        :return: None
+        """
+        with open(filename, 'w') as f:
+            for row in self.db:
+                f.write(sep.join(map(str, row.tolist())) + '\n')
+
+    def getTransactions(self) -> pd.DataFrame:
+        """
+        Get the binary database as a pandas DataFrame whose columns are item1..itemN.
+
+        :return: the binary database
+        :rtype: pd.DataFrame
+        """
+        columns = ["item" + str(j + 1) for j in range(self.numItems)]
+        return pd.DataFrame(self.db, columns=columns)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 5:
+        obj = generateBinaryDatabase(int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3]))
+        obj.create()
+        obj.save('\t', sys.argv[4])
+    else:
+        # default demonstration
+        obj = generateBinaryDatabase(10, 5, 10)
+        obj.create()
+        obj.save('\t', 'binaryDB.txt')
+        print(obj.getTransactions())

--- a/PAMI/extras/syntheticDataGenerator/BinaryDatabase.py
+++ b/PAMI/extras/syntheticDataGenerator/BinaryDatabase.py
@@ -1,0 +1,221 @@
+# BinaryDatabase generates a synthetic binary (0/1) transactional database. Each row is a transaction and each column is an item; a 1 means the item is present in that transaction. This is the native input format of the binary frequent-pattern miners (BinaryApriori, BinaryECLAT, BinaryFPGrowth).
+#
+#  **Importing this algorithm into a python program**
+#  --------------------------------------------------------
+#     from PAMI.extras.syntheticDataGenerator import BinaryDatabase as db
+#
+#     obj = db.BinaryDatabase(10, 5, 10)
+#
+#     obj.create()
+#
+#     obj.save('binaryDB.txt')
+#
+#     print(obj.getTransactions())
+#
+import numpy as np
+import pandas as pd
+import sys, psutil, os, time
+
+__copyright__ = """
+ Copyright (C)  2021 Rage Uday Kiran
+
+     This program is free software: you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+     the Free Software Foundation, either version 3 of the License, or
+     (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License
+     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+
+class BinaryDatabase:
+    """
+        :Description: BinaryDatabase generates a synthetic binary (0/1) transactional database where rows are transactions
+                      and columns are items. A 1 in column *j* of row *i* means item *j* is present in transaction *i*.
+                      The output is directly consumable by the binary frequent-pattern miners (BinaryApriori, BinaryECLAT,
+                      BinaryFPGrowth) and by the binaryDF2DB converter.
+
+        :Attributes:
+
+            databaseSize: int
+                Number of transactions (rows) in the database
+            avgItemsPerTransaction: int
+                Average number of present items (1s) per transaction
+            numItems: int
+                Total number of items (columns)
+            memoryUSS : float
+                To store the total amount of USS memory consumed by the program
+            memoryRSS : float
+                To store the total amount of RSS memory consumed by the program
+            startTime : float
+                To record the start time of the generation process
+            endTime : float
+                To record the completion time of the generation process
+
+        :Methods:
+
+            create:
+                Generate the binary transactional database
+            save:
+                Save the binary database to a user-specified file (one row of 0/1 values per line)
+            getTransactions:
+                Get the binary database as a pandas DataFrame (columns item1..itemN)
+            getMemoryUSS()
+                Total amount of USS memory consumed by the generation process will be retrieved from this function
+            getMemoryRSS()
+                Total amount of RSS memory consumed by the generation process will be retrieved from this function
+            getRuntime()
+                Total amount of runtime taken by the generation process will be retrieved from this function
+
+        **Methods to execute code on terminal**
+        ---------------------------------------------
+
+        .. code-block:: console
+
+          Format:
+
+          (.venv) $ python3 BinaryDatabase.py <databaseSize> <avgItemsPerTransaction> <numItems> <outputFile>
+
+          Example Usage:
+
+          (.venv) $ python3 BinaryDatabase.py 50 10 100 binaryDB.txt
+
+
+        **Importing this algorithm into a python program**
+        --------------------------------------------------------
+            from PAMI.extras.syntheticDataGenerator import BinaryDatabase as db
+
+            obj = db.BinaryDatabase(10, 5, 10)
+
+            obj.create()
+
+            obj.save('binaryDB.txt')
+
+            print(obj.getTransactions())
+
+
+        """
+
+    def __init__(self, databaseSize, avgItemsPerTransaction, numItems, sep="\t") -> None:
+        """
+        Initialize the binary database with the given parameters
+
+        :param databaseSize: total number of transactions (rows) in the database
+        :type databaseSize: int
+        :param avgItemsPerTransaction: average number of present items (1s) per transaction
+        :type avgItemsPerTransaction: int
+        :param numItems: total number of items (columns)
+        :type numItems: int
+        :param sep: separator used between the 0/1 values of a row
+        :type sep: str
+        """
+
+        self.databaseSize = databaseSize
+        self.avgItemsPerTransaction = avgItemsPerTransaction
+        self.numItems = numItems
+        self.sep = sep
+        self._matrix = None
+        self._startTime = float()
+        self._endTime = float()
+        self._memoryUSS = float()
+        self._memoryRSS = float()
+
+    @staticmethod
+    def _generateArray(databaseSize, avgItemsPerTransaction):
+        """
+        Generate per-row 1-counts whose average equals avgItemsPerTransaction (same weighting scheme used by
+        the other synthetic generators in this package).
+        """
+        transactionSize = np.random.rand(databaseSize)
+        sumTransactions = np.sum(transactionSize)
+        weights = transactionSize / sumTransactions
+        sumResultant = avgItemsPerTransaction * databaseSize
+        valuesInt = np.round(weights * sumResultant).astype(int)
+
+        indexZero = np.where(valuesInt == 0)[0]
+        for i in indexZero:
+            valuesInt[i] += 1
+        return valuesInt
+
+    def create(self) -> None:
+        """
+        Generate the binary transactional database as a (databaseSize x numItems) 0/1 matrix.
+        """
+        self._startTime = time.time()
+        counts = self._generateArray(self.databaseSize, self.avgItemsPerTransaction)
+        # A transaction cannot hold more distinct items than exist.
+        counts = np.clip(counts, 1, self.numItems)
+
+        matrix = np.zeros((self.databaseSize, self.numItems), dtype=np.uint8)
+        for i in range(self.databaseSize):
+            chosen = np.random.choice(self.numItems, counts[i], replace=False)
+            matrix[i, chosen] = 1
+        self._matrix = matrix
+        self._endTime = time.time()
+
+    def save(self, filename) -> None:
+        """
+        Save the binary database to a file, one transaction per line as sep-separated 0/1 values.
+
+        :param filename: name of the output file
+        :type filename: str
+        """
+        with open(filename, 'w') as f:
+            for row in self._matrix:
+                f.write(str(self.sep).join(map(str, row.tolist())) + '\n')
+
+    def getTransactions(self) -> pd.DataFrame:
+        """
+        Get the binary database as a pandas DataFrame whose columns are item1..itemN.
+
+        :return: the binary database
+        :rtype: pd.DataFrame
+        """
+        columns = ["item" + str(j + 1) for j in range(self.numItems)]
+        return pd.DataFrame(self._matrix, columns=columns)
+
+    def getMemoryUSS(self) -> float:
+        process = psutil.Process(os.getpid())
+        self._memoryUSS = process.memory_full_info().uss
+        return self._memoryUSS
+
+    def getMemoryRSS(self) -> float:
+        process = psutil.Process(os.getpid())
+        self._memoryRSS = process.memory_info().rss
+        return self._memoryRSS
+
+    def getRuntime(self) -> float:
+        return self._endTime - self._startTime
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 5:
+        obj = BinaryDatabase(int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3]))
+        obj.create()
+        obj.save(sys.argv[4])
+        print("Total Memory in USS:", obj.getMemoryUSS())
+        print("Total Memory in RSS", obj.getMemoryRSS())
+        print("Total ExecutionTime in ms:", obj.getRuntime())
+    elif len(sys.argv) == 6:
+        obj = BinaryDatabase(int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3]), sys.argv[4])
+        obj.create()
+        obj.save(sys.argv[5])
+        print("Total Memory in USS:", obj.getMemoryUSS())
+        print("Total Memory in RSS", obj.getMemoryRSS())
+        print("Total ExecutionTime in ms:", obj.getRuntime())
+    elif len(sys.argv) == 4:
+        obj = BinaryDatabase(int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3]))
+        obj.create()
+        print("Total Memory in USS:", obj.getMemoryUSS())
+        print("Total Memory in RSS", obj.getMemoryRSS())
+        print("Total ExecutionTime in ms:", obj.getRuntime())
+    else:
+        raise ValueError(
+            "Invalid number of arguments. Args: <databaseSize> <avgItemsPerTransaction> <numItems> <filename> "
+            "or Args: <databaseSize> <avgItemsPerTransaction> <numItems> <sep> <filename>")

--- a/PAMI/frequentPattern/binary/BinaryApriori.py
+++ b/PAMI/frequentPattern/binary/BinaryApriori.py
@@ -1,0 +1,451 @@
+# BinaryApriori discovers the complete set of frequent patterns directly from a binary (0/1) transactional dataset, where rows are transactions and columns are items. It avoids flattening the data to text by packing each item column into a bitset and counting support with a vectorised pop-count, while pruning the search space with the apriori (downward closure) property.
+#
+# **Importing this algorithm into a python program**
+#
+#             import PAMI.frequentPattern.basic.BinaryApriori as alg
+#
+#             import numpy as np
+#
+#             iFile = np.array([[1, 0, 1, 1], [0, 1, 1, 0]])  # rows = transactions, cols = items
+#
+#             minSup = 1  # can also be specified between 0 and 1
+#
+#             obj = alg.BinaryApriori(iFile, minSup)
+#
+#             obj.mine()
+#
+#             frequentPattern = obj.getPatterns()
+#
+#             print("Total number of Frequent Patterns:", len(frequentPattern))
+#
+#             obj.save(oFile)
+#
+#             Df = obj.getPatternsAsDataFrame()
+#
+#             memUSS = obj.getMemoryUSS()
+#
+#             print("Total Memory in USS:", memUSS)
+#
+#             memRSS = obj.getMemoryRSS()
+#
+#             print("Total Memory in RSS", memRSS)
+#
+#             run = obj.getRuntime()
+#
+#             print("Total ExecutionTime in seconds:", run)
+#
+
+
+__copyright__ = """
+Copyright (C)  2026 Rage Uday Kiran
+
+     This program is free software: you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+     the Free Software Foundation, either version 3 of the License, or
+     (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License
+     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from PAMI.frequentPattern.basic import abstract as _ab
+from typing import Dict, List, Tuple, Union
+from itertools import combinations as _combinations
+from deprecated import deprecated
+import numpy as _np
+
+
+class BinaryApriori(_ab._frequentPatterns):
+    """
+    **About this algorithm**
+
+    :**Description**: BinaryApriori discovers the complete set of frequent patterns directly from a *binary* (0/1) transactional dataset
+                      in which rows represent transactions and columns represent items. Unlike the text-based :class:`Apriori`, it accepts
+                      one-hot / boolean input as-is (the native format produced by tools such as ``mlxtend``) and therefore does not require
+                      the user to flatten the matrix into an item-token file first. Internally every item column is packed into a bitset
+                      (``numpy.packbits``) and the support of an itemset is obtained with a fully vectorised pop-count over the bitwise-AND
+                      of the participating columns. Candidate generation uses the classic apriori join-and-prune so that only itemsets whose
+                      every subset is frequent are ever counted.
+
+    :**Reference**:  Agrawal, R., Imieli ́nski, T., Swami, A.: Mining association rules between sets of items in large databases.
+                     In: SIGMOD. pp. 207–216 (1993), https://doi.org/10.1145/170035.170072
+
+    :**Parameters**:    - **iFile** (*numpy.ndarray or pandas.DataFrame or str*) -- *The binary dataset. A 2D 0/1 (or boolean) NumPy array, a binary/one-hot pandas DataFrame (column labels are used as item names), or a path to a whitespace/sep-separated 0/1 matrix file with an optional header row of item names. A DataFrame holding a single ``'Transactions'`` column is also accepted and one-hot encoded automatically.*
+                        - **oFile** (*str*) -- *Name of the output file to store complete set of frequent patterns.*
+                        - **minSup** (*int or float or str*) -- *The user can specify minSup either in count or proportion of database size. If the program detects the data type of minSup is integer, then it treats minSup is expressed in count. Otherwise, it will be treated as float.*
+                        - **sep** (*str*) -- *This variable is used to distinguish items from one another while reading a matrix file. The default separator is tab space. However, the users can override their default separator.*
+
+    :**Attributes**:    - **startTime** (*float*) -- *To record the start time of the mining process.*
+                        - **endTime** (*float*) -- *To record the completion time of the mining process.*
+                        - **finalPatterns** (*dict*) -- *Storing the complete set of patterns in a dictionary variable.*
+                        - **memoryUSS** (*float*) -- *To store the total amount of USS memory consumed by the program.*
+                        - **memoryRSS** (*float*) -- *To store the total amount of RSS memory consumed by the program.*
+
+
+    **Execution methods**
+
+    **Terminal command**
+
+    .. code-block:: console
+
+      Format:
+
+      (.venv) $ python3 BinaryApriori.py <inputFile> <outputFile> <minSup>
+
+      Example Usage:
+
+      (.venv) $ python3 BinaryApriori.py binaryDB.txt patterns.txt 10.0
+
+    .. note:: minSup can be specified  in support count or a value between 0 and 1.
+
+
+    **Calling from a python program**
+
+    .. code-block:: python
+
+            import PAMI.frequentPattern.basic.BinaryApriori as alg
+
+            import numpy as np
+
+            iFile = np.array([[1, 0, 1, 1], [0, 1, 1, 0]])  # rows = transactions, cols = items
+
+            minSup = 1  # can also be specified between 0 and 1
+
+            obj = alg.BinaryApriori(iFile, minSup)
+
+            obj.mine()
+
+            frequentPattern = obj.getPatterns()
+
+            print("Total number of Frequent Patterns:", len(frequentPattern))
+
+            obj.save(oFile)
+
+            Df = obj.getPatternsAsDataFrame()
+
+            memUSS = obj.getMemoryUSS()
+
+            print("Total Memory in USS:", memUSS)
+
+            memRSS = obj.getMemoryRSS()
+
+            print("Total Memory in RSS", memRSS)
+
+            run = obj.getRuntime()
+
+            print("Total ExecutionTime in seconds:", run)
+
+
+    **Credits**
+
+    The complete program was written under the supervision of Professor Rage Uday Kiran.
+
+    """
+
+    _minSup = float()
+    _startTime = float()
+    _endTime = float()
+    _finalPatterns = {}
+    _iFile = " "
+    _oFile = " "
+    _sep = " "
+    _memoryUSS = float()
+    _memoryRSS = float()
+
+    def __init__(self, iFile, minSup, sep="\t") -> None:
+        super().__init__(iFile, minSup, sep)
+        self._items: List[str] = []
+        self._packed = None          # uint8 bitsets, shape (nWords, nItems); column j is item j
+        self._nTransactions = 0
+
+    def _peekHeader(self, path: str) -> bool:
+        """
+        Returns True if the first line of ``path`` contains non-numeric tokens, in which case it is
+        treated as a header row carrying the item names.
+        """
+        with open(path, 'r', encoding='utf-8') as f:
+            first = f.readline().strip()
+        if not first:
+            return False
+        delimiter = None if self._sep in ('\t', ' ', '') else self._sep
+        tokens = first.split() if delimiter is None else first.split(delimiter)
+        for tok in tokens:
+            try:
+                float(tok)
+            except ValueError:
+                return True
+        return False
+
+    def _matrixFromTransactions(self, transactions: List[List[str]]) -> Tuple[_np.ndarray, List[str]]:
+        """
+        One-hot encode a list of item-token transactions into a boolean matrix and the sorted item vocabulary.
+        """
+        vocabulary = sorted({item for row in transactions for item in row})
+        position = {item: idx for idx, item in enumerate(vocabulary)}
+        matrix = _np.zeros((len(transactions), len(vocabulary)), dtype=bool)
+        for rowIdx, row in enumerate(transactions):
+            for item in row:
+                matrix[rowIdx, position[item]] = True
+        return matrix, vocabulary
+
+    def _creatingItemSets(self) -> None:
+        """
+        Loads the binary dataset from the supported input forms, stores the item names in ``self._items`` and the
+        bit-packed item columns in ``self._packed``. Each column of ``self._packed`` is the bitset of one item.
+        """
+        matrix = None
+        names = None
+
+        if isinstance(self._iFile, _np.ndarray):
+            matrix = self._iFile
+            names = ["item" + str(j + 1) for j in range(matrix.shape[1])] if matrix.ndim == 2 else []
+
+        elif isinstance(self._iFile, _ab._pd.DataFrame):
+            if self._iFile.empty:
+                self._items, self._nTransactions = [], 0
+                self._packed = _np.empty((0, 0), dtype=_np.uint8)
+                return
+            columns = self._iFile.columns.values.tolist()
+            if 'Transactions' in columns:
+                rows = [str(x).split(self._sep) for x in self._iFile['Transactions'].tolist()]
+                rows = [[i for i in row if i] for row in rows]
+                matrix, names = self._matrixFromTransactions(rows)
+            else:
+                matrix = self._iFile.to_numpy()
+                names = [str(c) for c in columns]
+
+        elif isinstance(self._iFile, str):
+            delimiter = None if self._sep in ('\t', ' ', '') else self._sep
+            if self._peekHeader(self._iFile):
+                with open(self._iFile, 'r', encoding='utf-8') as f:
+                    header = f.readline().strip()
+                names = header.split() if delimiter is None else header.split(delimiter)
+                matrix = _np.loadtxt(self._iFile, delimiter=delimiter, skiprows=1, ndmin=2)
+            else:
+                matrix = _np.loadtxt(self._iFile, delimiter=delimiter, ndmin=2)
+                names = ["item" + str(j + 1) for j in range(matrix.shape[1])]
+        else:
+            raise TypeError("iFile must be a numpy.ndarray, a pandas.DataFrame or a path to a binary matrix file")
+
+        matrix = _np.asarray(matrix)
+        if matrix.ndim != 2 or matrix.size == 0:
+            self._items, self._nTransactions = [], 0
+            self._packed = _np.empty((0, 0), dtype=_np.uint8)
+            return
+
+        boolMatrix = matrix.astype(bool)
+        self._items = [str(n) for n in names]
+        self._nTransactions = boolMatrix.shape[0]
+        # Pack each item column along the transaction axis -> bitset per item (column j).
+        self._packed = _np.packbits(boolMatrix, axis=0)
+
+    def _convert(self, value: Union[int, float, str]) -> Union[int, float]:
+        """
+        To convert the user specified minSup value into an absolute support count.
+
+        :param value: user specified minSup value
+        :type value: int or float or str
+        :return: converted minSup
+        :rtype: int or float
+        """
+        if type(value) is int:
+            value = int(value)
+        if type(value) is float:
+            value = (self._nTransactions * value)
+        if type(value) is str:
+            if '.' in value:
+                value = float(value)
+                value = (self._nTransactions * value)
+            else:
+                value = int(value)
+        return value
+
+    @deprecated("It is recommended to use 'mine()' instead of 'startMine()' for mining process. Starting from January 2025, 'startMine()' will be completely terminated.")
+    def startMine(self) -> None:
+        """
+        Frequent pattern mining process will start from here
+        """
+        self.mine()
+
+    def mine(self) -> None:
+        """
+        Frequent pattern mining process will start from here.
+        """
+        self._startTime = _ab._time.time()
+        self._finalPatterns = {}
+        self._creatingItemSets()
+        self._minSup = self._convert(self._minSup)
+
+        if self._nTransactions == 0 or self._packed.shape[1] == 0:
+            self._endTime = _ab._time.time()
+            process = _ab._psutil.Process(_ab._os.getpid())
+            self._memoryUSS = process.memory_full_info().uss
+            self._memoryRSS = process.memory_info().rss
+            print("Frequent patterns were generated successfully using BinaryApriori algorithm ")
+            return
+
+        # 256-entry pop-count lookup table: number of set bits for every possible byte value.
+        popcount = _np.unpackbits(_np.arange(256, dtype=_np.uint8)[:, None], axis=1).sum(axis=1).astype(_np.int64)
+
+        # ---- Level 1: frequent single items ----
+        itemSupports = popcount[self._packed].sum(axis=0)            # support of every item, vectorised
+        frequentCols = _np.where(itemSupports >= self._minSup)[0]    # ascending column indices
+
+        # Per-itemset state for the current level:
+        #   indexTuples : sorted tuples of integer column ids (used for join / prune)
+        #   bitsets     : row-major uint8 bitsets, bitsets[i] is the AND of itemset i's columns
+        indexTuples: List[Tuple[int, ...]] = [(int(c),) for c in frequentCols]
+        bitsets = self._packed[:, frequentCols].T.copy() if frequentCols.size else _np.empty((0, self._packed.shape[0]), dtype=_np.uint8)
+        for i, c in enumerate(frequentCols):
+            self._finalPatterns[(self._items[c],)] = int(itemSupports[c])
+
+        # ---- Levels k >= 2: apriori join + prune, batched AND + pop-count ----
+        k = 2
+        while len(indexTuples) > 1:
+            prevFreq = set(indexTuples)
+            leftIdx: List[int] = []
+            rightIdx: List[int] = []
+            candTuples: List[Tuple[int, ...]] = []
+
+            m = len(indexTuples)
+            i = 0
+            while i < m:
+                # Items sharing the same (k-2)-prefix are contiguous because indexTuples is sorted.
+                j = i + 1
+                prefix = indexTuples[i][:-1]
+                while j < m and indexTuples[j][:-1] == prefix:
+                    j += 1
+                for a in range(i, j):
+                    for b in range(a + 1, j):
+                        candidate = indexTuples[a] + (indexTuples[b][-1],)
+                        if k > 2:
+                            # Prune: every (k-1)-subset of the candidate must be frequent.
+                            if any(sub not in prevFreq for sub in _combinations(candidate, k - 1)):
+                                continue
+                        leftIdx.append(a)
+                        rightIdx.append(b)
+                        candTuples.append(candidate)
+                i = j
+
+            if not candTuples:
+                break
+
+            # Support of every surviving candidate in one batched bitwise-AND + pop-count.
+            left = bitsets[leftIdx]
+            right = bitsets[rightIdx]
+            candBitsets = left & right
+            supports = popcount[candBitsets].sum(axis=1)
+            keep = supports >= self._minSup
+
+            nextTuples: List[Tuple[int, ...]] = []
+            nextRows: List[int] = []
+            for pos in _np.where(keep)[0]:
+                candidate = candTuples[pos]
+                nextTuples.append(candidate)
+                nextRows.append(pos)
+                self._finalPatterns[tuple(self._items[c] for c in candidate)] = int(supports[pos])
+
+            if not nextTuples:
+                break
+            indexTuples = nextTuples
+            bitsets = candBitsets[nextRows].copy()   # keep only frequent rows for the next level
+            k += 1
+
+        self._endTime = _ab._time.time()
+        process = _ab._psutil.Process(_ab._os.getpid())
+        self._memoryUSS = process.memory_full_info().uss
+        self._memoryRSS = process.memory_info().rss
+        print("Frequent patterns were generated successfully using BinaryApriori algorithm ")
+
+    def getMemoryUSS(self) -> float:
+        """
+        Total amount of USS memory consumed by the mining process will be retrieved from this function
+
+        :return: returning USS memory consumed by the mining process
+        :rtype: float
+        """
+        return self._memoryUSS
+
+    def getMemoryRSS(self) -> float:
+        """
+        Total amount of RSS memory consumed by the mining process will be retrieved from this function
+
+        :return: returning RSS memory consumed by the mining process
+        :rtype: float
+        """
+        return self._memoryRSS
+
+    def getRuntime(self) -> float:
+        """
+        Calculating the total amount of runtime taken by the mining process
+
+        :return: returning total amount of runtime taken by the mining process
+        :rtype: float
+        """
+        return self._endTime - self._startTime
+
+    def getPatternsAsDataFrame(self) -> _ab._pd.DataFrame:
+        """
+        Storing final frequent patterns in a dataframe
+
+        :return: returning frequent patterns in a dataframe
+        :rtype: pd.DataFrame
+        """
+        dataFrame = _ab._pd.DataFrame(list([[self._sep.join(x), y] for x, y in self._finalPatterns.items()]),
+                                      columns=['Patterns', 'Support'])
+        return dataFrame
+
+    def save(self, oFile: str, seperator="\t") -> None:
+        """
+        Complete set of frequent patterns will be loaded in to an output file
+
+        :param oFile: name of the output file
+        :type oFile: csvfile
+        :param seperator: variable to store separator value
+        :type seperator: string
+        :return: None
+        """
+        with open(oFile, 'w') as f:
+            for x, y in self._finalPatterns.items():
+                x = seperator.join(x)
+                f.write(f"{x}:{y}\n")
+
+    def getPatterns(self) -> Dict[Tuple[str, ...], int]:
+        """
+        Function to send the set of frequent patterns after completion of the mining process
+
+        :return: returning frequent patterns
+        :rtype: dict
+        """
+        return self._finalPatterns
+
+    def printResults(self) -> None:
+        """
+        This function is used to print the result
+        """
+        print("Total number of Frequent Patterns:", len(self.getPatterns()))
+        print("Total Memory in USS:", self.getMemoryUSS())
+        print("Total Memory in RSS", self.getMemoryRSS())
+        print("Total ExecutionTime in ms:", self.getRuntime())
+
+
+if __name__ == "__main__":
+    _ap = str()
+    if len(_ab._sys.argv) == 4 or len(_ab._sys.argv) == 5:
+        if len(_ab._sys.argv) == 5:
+            _ap = BinaryApriori(_ab._sys.argv[1], _ab._sys.argv[3], _ab._sys.argv[4])
+        if len(_ab._sys.argv) == 4:
+            _ap = BinaryApriori(_ab._sys.argv[1], _ab._sys.argv[3])
+        _ap.mine()
+        print("Total number of Frequent Patterns:", len(_ap.getPatterns()))
+        _ap.save(_ab._sys.argv[2])
+        print("Total Memory in USS:", _ap.getMemoryUSS())
+        print("Total Memory in RSS", _ap.getMemoryRSS())
+        print("Total ExecutionTime in ms:", _ap.getRuntime())
+    else:
+        print("Error! The number of input parameters do not match the total number of parameters provided")

--- a/PAMI/geoReferencedPeriodicFrequentPattern/basic/GPFPMiner.py
+++ b/PAMI/geoReferencedPeriodicFrequentPattern/basic/GPFPMiner.py
@@ -253,6 +253,8 @@ class GPFPMiner(_ab._geoReferencedPeriodicFrequentPatterns):
 
         candidate = {}
         for i in self._Database:
+            if not i:
+                continue
             self._lno += 1
             n = int(i[0])
             for j in i[1:]:
@@ -362,7 +364,7 @@ class GPFPMiner(_ab._geoReferencedPeriodicFrequentPatterns):
             itemSetX = [itemX]
             neighboursItemsI = self._getNeighbourItems(itemSets[i])
             for j in range(i + 1, len(itemSets)):
-                neighboursItemsJ = self._getNeighbourItems(itemSets[i])
+                neighboursItemsJ = self._getNeighbourItems(itemSets[j])
                 if not itemSets[j] in neighboursItemsI:
                     continue
                 itemJ = itemSets[j]
@@ -419,18 +421,20 @@ class GPFPMiner(_ab._geoReferencedPeriodicFrequentPatterns):
             if _ab._validators.url(self._nFile):
                 data = _ab._urlopen(self._nFile)
                 for line in data:
-                    line.strip()
                     line = line.decode("utf-8")
                     temp = [i.rstrip() for i in line.split(self._sep)]
                     temp = [x for x in temp if x]
+                    if not temp:      # skip blank lines (e.g. a trailing newline)
+                        continue
                     self._NeighboursMap[temp[0]] = temp[1:]
             else:
                 try:
                     with open(self._nFile, 'r', encoding='utf-8') as f:
                         for line in f:
-                            line.strip()
                             temp = [i.rstrip() for i in line.split(self._sep)]
                             temp = [x for x in temp if x]
+                            if not temp:      # skip blank lines (e.g. a trailing newline)
+                                continue
                             self._NeighboursMap[temp[0]] = temp[1:]
                 except IOError:
                     print("File Not Found")
@@ -453,10 +457,12 @@ class GPFPMiner(_ab._geoReferencedPeriodicFrequentPatterns):
         self._startTime = _ab._time.time()
         if self._iFile is None:
             raise Exception("Please enter the file path or file name:")
+        self._lno = 0
         self._creatingItemSets()
-        self._minSup = self._convert(self._minSup)
         self.mapNeighbours()
         self._finalPatterns = {}
+        # _frequentOneItem() converts minSup and maxPer; converting minSup here as well would
+        # scale a float/percentage threshold twice (e.g. 0.5 -> 5 -> 50) and silently drop patterns.
         plist = self._frequentOneItem()
         for i in range(len(plist)):
             itemX = plist[i]
@@ -573,7 +579,6 @@ if __name__ == "__main__":
             _ap = GPFPMiner(_ab._sys.argv[1], _ab._sys.argv[3], _ab._sys.argv[4], _ab._sys.argv[5], _ab._sys.argv[6])
         if len(_ab._sys.argv) == 6:
             _ap = GPFPMiner(_ab._sys.argv[1], _ab._sys.argv[3], _ab._sys.argv[4], _ab._sys.argv[5])
-        _ap.mine()
         _ap.mine()
         print("Total number of Spatial Periodic-Frequent Patterns:", len(_ap.getPatterns()))
         _ap.save(_ab._sys.argv[2])

--- a/PAMI/multipleMinimumSupportBasedFrequentPattern/basic/CFPGrowth.py
+++ b/PAMI/multipleMinimumSupportBasedFrequentPattern/basic/CFPGrowth.py
@@ -408,7 +408,7 @@ class CFPGrowth(_fp._frequentPatterns):
                     with open(self._iFile, 'r', encoding='utf-8') as f:
                         for line in f:
                             line = line.strip()
-                            temp = [i.rstrip() for i in line.split('\t')]
+                            temp = [i.rstrip() for i in line.split(self._sep)]
                             temp = [x for x in temp if x]
                             # print(temp)
                             self.__Database.append(temp)
@@ -559,6 +559,7 @@ class CFPGrowth(_fp._frequentPatterns):
 
         """
         global _MIS
+        _MIS = {}  # reset shared state so repeated runs / multiple instances do not leak stale ranks
         self.__startTime = _fp._time.time()
         if self._iFile is None:
             raise Exception("Please enter the file path or file name:")

--- a/PAMI/multipleMinimumSupportBasedFrequentPattern/basic/CFPGrowthPlus.py
+++ b/PAMI/multipleMinimumSupportBasedFrequentPattern/basic/CFPGrowthPlus.py
@@ -508,7 +508,7 @@ class CFPGrowthPlus(_fp._frequentPatterns):
         """
         temp = str()
         for i in itemSet:
-            temp = temp + self.__rankDup[i] + " "
+            temp = temp + self.__rankDup[i] + "\t"
         return temp
 
     @deprecated("It is recommended to use mine() instead of mine() for mining process")
@@ -524,7 +524,9 @@ class CFPGrowthPlus(_fp._frequentPatterns):
         main program to start the operation
 
         """
-        global MIS
+        global MIS, minMIS
+        MIS = {}       # reset shared state so repeated runs / multiple instances do not leak stale ranks
+        minMIS = 0
         self.__startTime = _fp._time.time()
         if self._iFile is None:
             raise Exception("Please enter the file path or file name:")
@@ -589,7 +591,7 @@ class CFPGrowthPlus(_fp._frequentPatterns):
         dataframe = {}
         data = []
         for a, b in self.__finalPatterns.items():
-            data.append([a, b])
+            data.append([a.replace('\t', ' '), b])
             dataframe = _fp._pd.DataFrame(data, columns=['Patterns', 'Support'])
         return dataframe
 
@@ -602,7 +604,7 @@ class CFPGrowthPlus(_fp._frequentPatterns):
         self._oFile = outFile
         writer = open(self._oFile, 'w+')
         for x, y in self.__finalPatterns.items():
-            s1 = x + ":" + str(y)
+            s1 = x.strip() + ":" + str(y)
             writer.write("%s \n" % s1)
 
     def getPatterns(self):


### PR DESCRIPTION
Added binary database generators and BinaryApriori; fix miner bugs, Adds two synthetic binary-database generators and the BinaryApriori frequent-pattern miner. Also fixes bugs in GPFPMiner, CFPGrowth and CFPGrowthPlus: minSup converted twice (float thresholds returned no patterns), a hardcoded separator, blank-line crashes, a stale neighbour index, shared-state leaks between runs, and inconsistent output formatting.